### PR TITLE
[FIX] Hooks are called because overriden enabled

### DIFF
--- a/client/src/components/Earn/EarnBoxPersonalAllocation/EarnBoxPersonalAllocation.tsx
+++ b/client/src/components/Earn/EarnBoxPersonalAllocation/EarnBoxPersonalAllocation.tsx
@@ -36,7 +36,7 @@ const EarnBoxPersonalAllocation: FC<EarnBoxPersonalAllocationProps> = ({ classNa
   const { data: individualReward, isFetching: isFetchingIndividualReward } = useIndividualReward();
   const { data: isPatronMode } = useIsPatronMode();
   const { data: totalPatronDonations, isFetching: isFetchingTotalPatronDonations } =
-    useTotalPatronDonations({ enabled: isPatronMode });
+    useTotalPatronDonations({ isEnabledAdditional: !!isPatronMode });
   const { isAppWaitingForTransactionToBeIndexed } = useTransactionLocalStore(state => ({
     isAppWaitingForTransactionToBeIndexed: state.data.isAppWaitingForTransactionToBeIndexed,
   }));

--- a/client/src/hooks/helpers/useEpochPatronsAllEpochs.ts
+++ b/client/src/hooks/helpers/useEpochPatronsAllEpochs.ts
@@ -1,17 +1,19 @@
-import { useQueries, UseQueryOptions, UseQueryResult } from '@tanstack/react-query';
+import { useQueries, UseQueryResult } from '@tanstack/react-query';
 
 import { apiGetEpochPatrons, Response } from 'api/calls/epochPatrons';
 import { QUERY_KEYS } from 'api/queryKeys';
 import useCurrentEpoch from 'hooks/queries/useCurrentEpoch';
 
-export default function useEpochPatronsAllEpochs(
-  options?: Omit<UseQueryOptions<Response, Error, Response, any>, 'queryKey'>,
-): { data: string[][]; isFetching: boolean } {
+export default function useEpochPatronsAllEpochs({
+  isEnabledAdditional,
+}: {
+  isEnabledAdditional?: boolean;
+} = {}): { data: string[][]; isFetching: boolean } {
   const { data: currentEpoch, isFetching: isFetchingCurrentEpoch } = useCurrentEpoch();
 
   const epochPatronsAllEpochs: UseQueryResult<Response>[] = useQueries({
     queries: [...Array(currentEpoch).keys()].map(epoch => ({
-      enabled: currentEpoch !== undefined && currentEpoch > 1,
+      enabled: currentEpoch !== undefined && currentEpoch > 1 && isEnabledAdditional,
       queryFn: async () => {
         try {
           return await apiGetEpochPatrons(epoch);
@@ -24,7 +26,6 @@ export default function useEpochPatronsAllEpochs(
       },
       queryKey: QUERY_KEYS.epochPatrons(epoch),
       retry: false,
-      ...options,
     })),
   });
 

--- a/client/src/hooks/helpers/useIndividualRewardAllEpochs.ts
+++ b/client/src/hooks/helpers/useIndividualRewardAllEpochs.ts
@@ -1,4 +1,4 @@
-import { UseQueryOptions, useQueries } from '@tanstack/react-query';
+import { useQueries } from '@tanstack/react-query';
 import { useAccount } from 'wagmi';
 
 import { apiGetIndividualRewards, Response } from 'api/calls/individualRewards';
@@ -6,15 +6,17 @@ import { QUERY_KEYS } from 'api/queryKeys';
 import useCurrentEpoch from 'hooks/queries/useCurrentEpoch';
 import { parseUnitsBigInt } from 'utils/parseUnitsBigInt';
 
-export default function useIndividualRewardAllEpochs(
-  options?: Omit<UseQueryOptions<Response, Error, Response, any>, 'queryKey'>,
-): { data: bigint[]; isFetching: boolean } {
+export default function useIndividualRewardAllEpochs({
+  isEnabledAdditional,
+}: {
+  isEnabledAdditional?: boolean;
+} = {}): { data: bigint[]; isFetching: boolean } {
   const { address } = useAccount();
   const { data: currentEpoch, isFetching: isFetchingCurrentEpoch } = useCurrentEpoch();
 
   const individualRewardAllEpochs = useQueries({
     queries: [...Array(currentEpoch).keys()].map(epoch => ({
-      enabled: !!address && currentEpoch !== undefined && currentEpoch > 1,
+      enabled: !!address && currentEpoch !== undefined && currentEpoch > 1 && isEnabledAdditional,
       queryFn: async () => {
         try {
           return await apiGetIndividualRewards(epoch, address!);
@@ -26,7 +28,6 @@ export default function useIndividualRewardAllEpochs(
       },
       queryKey: QUERY_KEYS.individualReward(epoch),
       retry: false,
-      ...options,
     })),
   });
 

--- a/client/src/hooks/helpers/useTotalPatronDonations.ts
+++ b/client/src/hooks/helpers/useTotalPatronDonations.ts
@@ -1,19 +1,22 @@
-import { UseQueryOptions } from '@tanstack/react-query';
 import { useAccount } from 'wagmi';
 
 import useEpochPatronsAllEpochs from './useEpochPatronsAllEpochs';
 import useIndividualRewardAllEpochs from './useIndividualRewardAllEpochs';
 
-export default function useTotalPatronDonations(options?: Omit<UseQueryOptions<any>, 'queryKey'>): {
+export default function useTotalPatronDonations({
+  isEnabledAdditional,
+}: {
+  isEnabledAdditional: boolean;
+}): {
   data: bigint | undefined;
   isFetching: boolean;
 } {
   const { address } = useAccount();
 
   const { data: individualRewardAllEpochs, isFetching: isFetchingIndividualReward } =
-    useIndividualRewardAllEpochs(options);
+    useIndividualRewardAllEpochs({ isEnabledAdditional });
   const { data: epochPatronsAllEpochs, isFetching: isFetchingEpochPatronsAllEpochs } =
-    useEpochPatronsAllEpochs(options);
+    useEpochPatronsAllEpochs({ isEnabledAdditional });
 
   const isFetching = isFetchingIndividualReward || isFetchingEpochPatronsAllEpochs;
 


### PR DESCRIPTION
Right now hooks are called in `EarnView` because `enabled` flag is overriden instead of being combined.