### PR TITLE
[TEST] CY - projectsArchive - additional checks for skeletons

### DIFF
--- a/client/cypress/e2e/projectsArchive.cy.ts
+++ b/client/cypress/e2e/projectsArchive.cy.ts
@@ -41,6 +41,7 @@ Object.values(viewports).forEach(({ device, viewportWidth, viewportHeight }) => 
       cy.get('[data-test=MainLayout__body]').then(el => {
         const mainLayoutPaddingTop = parseInt(el.css('paddingTop'), 10);
 
+        cy.get('[data-test^=ProjectItemSkeleton').should('not.exist');
         cy.get('[data-test=ProjectsView__ProjectsList]')
           .should('be.visible')
           .children()
@@ -53,6 +54,7 @@ Object.values(viewports).forEach(({ device, viewportWidth, viewportHeight }) => 
 
             // list test
             cy.get('[data-test=ProjectsView__ProjectsList--archive]').first().should('be.visible');
+            cy.get('[data-test^=ProjectItemSkeleton').should('not.exist');
             cy.get('[data-test=ProjectsView__ProjectsList--archive]')
               .first()
               .children()
@@ -80,6 +82,7 @@ Object.values(viewports).forEach(({ device, viewportWidth, viewportHeight }) => 
                       .should('have.length', 1);
                   }
 
+                  cy.get('[data-test^=ProjectItemSkeleton').should('not.exist');
                   cy.get(`[data-test=ProjectsView__ProjectsListItem--archive--${i}]`)
                     .first()
                     .invoke('data', 'address')


### PR DESCRIPTION
CI run failed [here](https://github.com/golemfoundation/octant/actions/runs/8520944618/job/23338399322). Possibly because it asserted archive before it could fully load. Additional assertions for skeletons should help.