### PR TITLE
OCT-1595 Rewards calculator should not send requests when local validation failed

### DIFF
--- a/client/src/components/Earn/EarnRewardsCalculator/EarnRewardsCalculator.tsx
+++ b/client/src/components/Earn/EarnRewardsCalculator/EarnRewardsCalculator.tsx
@@ -1,6 +1,7 @@
 import cx from 'classnames';
 import { useFormik } from 'formik';
 import debounce from 'lodash/debounce';
+import isEmpty from 'lodash/isEmpty';
 import React, { FC, useCallback, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 
@@ -82,7 +83,10 @@ const EarnRewardsCalculator: FC = () => {
     if (!formik.values.valueCrypto || !formik.values.days) {
       return;
     }
-    formik.validateForm().then(() => {
+    formik.validateForm().then(errors => {
+      if (!isEmpty(errors)) {
+        return;
+      }
       fetchEstimatedRewardsDebounced({
         amountGlm: formik.values.valueCrypto,
         numberOfDays: formik.values.days,
@@ -99,7 +103,7 @@ const EarnRewardsCalculator: FC = () => {
   }, []);
 
   const estimatedFormattedRewardsValue: FormattedCryptoValue =
-    formik.values.valueCrypto && formik.values.days && calculateRewards
+    isEmpty(formik.errors) && formik.values.valueCrypto && formik.values.days && calculateRewards
       ? getFormattedEthValue(parseUnitsBigInt(calculateRewards.budget, 'wei'))
       : {
           fullString: '',


### PR DESCRIPTION
## Description

## Definition of Done

1. [ ] Acceptance criteria are met.
2. [ ] PR is manually tested before the merge by developer(s).
    - [ ] Happy path is manually checked.
3. [ ] PR is manually tested by QA when their assistance is required (1).
    - [ ] Octant Areas & Test Cases are checked for impact and updated if required (2).
4. [ ] Unit tests are added unless there is a reason to omit them.
5. [ ] Automated tests are added when required.
6. [ ] The code is merged.
7. [ ] Tech documentation is added / updated, reviewed and approved (including mandatory approval by a code owner, should such exist for changed files).
    - [ ] BE: Swagger documentation is updated.
8. [ ] When required by QA:
    - [ ] Deployed to the relevant environment.
    - [ ] Passed system tests.

---

(1) Developer(s) in coordination with QA decide whether it's required. For small tickets introducing small changes QA assistance is most probably not required.

(2) [Octant Areas & Test Cases](https://docs.google.com/spreadsheets/d/1cRe6dxuKJV3a4ZskAwWEPvrFkQm6rEfyUCYwLTYw_Cc).
