### PR TITLE
fix: attempt to fix "reorg error", leads to flaky tests

### DIFF
--- a/backend/app/infrastructure/__init__.py
+++ b/backend/app/infrastructure/__init__.py
@@ -72,6 +72,6 @@ class GQLConnectionFactory:
         client = Client()
         transport = RequestsHTTPTransport(url=self._url, timeout=2)
         client.transport = transport
-        client.fetch_schema_from_transport = True
+        client.fetch_schema_from_transport = False
 
         return client


### PR DESCRIPTION
This is the message:

```
gql.transport.exceptions.TransportQueryError: Error while fetching schema: {'message': 'the chain was reorganized while executing the query'}
If you don't need the schema, you can try with: "fetch_schema_from_transport=False"
```

## Description

## Definition of Done

1. [ ] Acceptance criteria are met.
2. [ ] PR is manually tested before the merge by developer(s).
    - [ ] Happy path is manually checked.
3. [ ] PR is manually tested by QA when their assistance is required (1).
    - [ ] Octant Areas & Test Cases are checked for impact and updated if required (2).
4. [ ] Unit tests are added unless there is a reason to omit them.
5. [ ] Automated tests are added when required.
6. [ ] The code is merged.
7. [ ] Tech documentation is added / updated, reviewed and approved (including mandatory approval by a code owner, should such exist for changed files).
    - [ ] BE: Swagger documentation is updated.
8. [ ] When required by QA:
    - [ ] Deployed to the relevant environment.
    - [ ] Passed system tests.

---

(1) Developer(s) in coordination with QA decide whether it's required. For small tickets introducing small changes QA assistance is most probably not required.

(2) [Octant Areas & Test Cases](https://docs.google.com/spreadsheets/d/1cRe6dxuKJV3a4ZskAwWEPvrFkQm6rEfyUCYwLTYw_Cc).
