### PR TITLE
OCT-1643: Teardown session after request finished

### DIFF
--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -31,7 +31,7 @@ def create_app(config=None):
         template_folder=f"{config.PROJECT_ROOT}/templates",
         static_folder=f"{config.PROJECT_ROOT}/static",
     )
-    app.teardown_request(teardown_session)
+
     app.config.from_object(config)
 
     register_extensions(app)
@@ -58,7 +58,3 @@ def register_extensions(app):
 def register_errorhandlers(app):
     handler = ExceptionHandler()
     app.register_error_handler(Exception, handler)
-
-
-def teardown_session(*args, **kwargs):
-    db.session.remove()

--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -2,6 +2,7 @@ import os
 
 from flask import Flask
 
+from app.engine.epochs_settings import register_epoch_settings
 from app.extensions import (
     db,
     migrate,
@@ -13,12 +14,11 @@ from app.extensions import (
     init_scheduler,
     init_subgraph,
 )
-from app.logging import init_logger
 from app.infrastructure import events, routes, apscheduler  # noqa
 from app.infrastructure.exception_handler import ExceptionHandler
-from app.settings import ProdConfig, DevConfig
-from app.engine.epochs_settings import register_epoch_settings
+from app.logging import init_logger
 from app.modules.registry import register_services
+from app.settings import ProdConfig, DevConfig
 
 
 def create_app(config=None):
@@ -31,6 +31,7 @@ def create_app(config=None):
         template_folder=f"{config.PROJECT_ROOT}/templates",
         static_folder=f"{config.PROJECT_ROOT}/static",
     )
+    app.teardown_request(teardown_session)
     app.config.from_object(config)
 
     register_extensions(app)
@@ -57,3 +58,7 @@ def register_extensions(app):
 def register_errorhandlers(app):
     handler = ExceptionHandler()
     app.register_error_handler(Exception, handler)
+
+
+def teardown_session(*args, **kwargs):
+    db.session.remove()

--- a/backend/startup.py
+++ b/backend/startup.py
@@ -11,6 +11,7 @@
 # we prevent this monkeypatching
 
 import os
+from app.extensions import db
 
 os.environ["EVENTLET_NO_GREENDNS"] = "yes"
 import eventlet  # noqa
@@ -19,6 +20,12 @@ eventlet.monkey_patch()
 from app import create_app  # noqa
 
 app = create_app()
+
+
+@app.teardown_request
+def teardown_session(*args, **kwargs):
+    db.session.remove()
+
 
 if __name__ == "__main__":
     eventlet.wsgi.server(eventlet.listen(("0.0.0.0", 5000)), app, log=app.logger)


### PR DESCRIPTION
## Description
My hypothesis is that the database scoped-sessions (that are implicitly created for each flask request) aren't closed properly. It results in the need for creating additional database connections to handle these "idle" sessions and then it makes the overflow. The idea is to make sure that we do ```db.session.remove()``` when every request is retrieved in our Flask application (as it comes out from SO threads and documentation, it doesn't happen automatically)


## Definition of Done

1. [ ] Acceptance criteria are met.
2. [ ] PR is manually tested before the merge by developer(s).
    - [ ] Happy path is manually checked.
3. [ ] PR is manually tested by QA when their assistance is required (1).
    - [ ] Octant Areas & Test Cases are checked for impact and updated if required (2).
4. [ ] Unit tests are added unless there is a reason to omit them.
5. [ ] Automated tests are added when required.
6. [ ] The code is merged.
7. [ ] Tech documentation is added / updated, reviewed and approved (including mandatory approval by a code owner, should such exist for changed files).
    - [ ] BE: Swagger documentation is updated.
8. [ ] When required by QA:
    - [ ] Deployed to the relevant environment.
    - [ ] Passed system tests.

---

(1) Developer(s) in coordination with QA decide whether it's required. For small tickets introducing small changes QA assistance is most probably not required.

(2) [Octant Areas & Test Cases](https://docs.google.com/spreadsheets/d/1cRe6dxuKJV3a4ZskAwWEPvrFkQm6rEfyUCYwLTYw_Cc).
