### PR TITLE
Minor improvements for apitest and localenv

### DIFF
--- a/localenv/anvil/Dockerfile
+++ b/localenv/anvil/Dockerfile
@@ -1,4 +1,4 @@
-FROM europe-docker.pkg.dev/wildland-dev/octant-test/foundry:latest
+FROM europe-docker.pkg.dev/wildland-dev/internal/octant/anvil:latest
 
 WORKDIR /home/foundry
 

--- a/localenv/apitest.yaml
+++ b/localenv/apitest.yaml
@@ -27,6 +27,12 @@ services:
       CHAIN_ID: "1337"
       CHAIN_NAME: "localhost"
 
+      GC_PASSPORT_SCORER_API_KEY: "${GC_PASSPORT_SCORER_API_KEY}"
+      GC_PASSPORT_SCORER_ID: "${GC_PASSPORT_SCORER_ID}"
+
+      DELEGATION_SALT: "salt"
+      DELEGATION_SALT_PRIMARY: "salt_primary"
+
     depends_on:
       - anvil
       - graph-node

--- a/localenv/localenv.yaml
+++ b/localenv/localenv.yaml
@@ -42,6 +42,12 @@ services:
       CHAIN_ID: "1337"
       CHAIN_NAME: "localhost"
 
+      GC_PASSPORT_SCORER_API_KEY: "${GC_PASSPORT_SCORER_API_KEY}"
+      GC_PASSPORT_SCORER_ID: "${GC_PASSPORT_SCORER_ID}"
+
+      DELEGATION_SALT: "salt"
+      DELEGATION_SALT_PRIMARY: "salt_primary"
+
     depends_on:
       - backend-postgres
       - anvil

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "apitest:up": "docker compose -p apitest -f ./localenv/docker-compose.yaml -f ./localenv/apitest.yaml up anvil ipfs graph-postgres graph-node multideployer",
     "apitest:down": "docker compose -p apitest -f ./localenv/docker-compose.yaml -f ./localenv/apitest.yaml down",
     "apitest:run": "docker compose -p apitest -f ./localenv/docker-compose.yaml -f ./localenv/apitest.yaml run backend-apitest",
-    "preapitest:up": "docker rm -v -f $(docker ps -qa --filter 'name=apitest')",
+    "preapitest:up": "docker rm -v -f $(docker ps -qa --filter 'name=apitest') || true",
     "preapitest:run": "yarn localenv:build-backend"
   },
   "repository": {


### PR DESCRIPTION
* don't crash if there are no containers to cleanup when setting up apitest
* add missing env variables (related to gitcoin passport and delegation)
* use correct link to anvil image