### PR TITLE
FIX-OCT-1839: Set created_at field

### DIFF
--- a/backend/migrations/versions/8b425b454a86_fix_created_at_field.py
+++ b/backend/migrations/versions/8b425b454a86_fix_created_at_field.py
@@ -1,0 +1,28 @@
+"""Fix created_at field
+
+Revision ID: 8b425b454a86
+Revises: 999999999999
+Create Date: 2024-08-02 12:32:50.490759
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+revision = "8b425b454a86"
+down_revision = "999999999999"
+branch_labels = None
+depends_on = None
+
+HASH1 = "a1ee927c11efc35ffef40fa51547e0770df76aab9085da332311ac9d629fa518"
+HASH2 = "f6b78725294faab4442f38aedb97ff7bc8fcaf9d73edf9845e1c57496e6d2913"
+HASH3 = "93bf4d5bb695b96edd45c0d4eae59fe3f5ecc657f7137407288fd82834476a0b"
+
+
+def upgrade():
+    query = f"UPDATE score_delegation SET created_at = make_date(2024, 7, 17) WHERE hashed_addr IN ('{HASH1}', '{HASH2}', '{HASH3}');"
+    op.execute(query)
+
+
+def downgrade():
+    query = f"UPDATE score_delegation SET created_at = NULL WHERE hashed_addr IN ('{HASH1}', '{HASH2}', '{HASH3}');"
+    op.execute(query)


### PR DESCRIPTION
## Description

## Definition of Done

1. [ ] Acceptance criteria are met.
2. [ ] PR is manually tested before the merge by developer(s).
    - [ ] Happy path is manually checked.
3. [ ] PR is manually tested by QA when their assistance is required (1).
    - [ ] Octant Areas & Test Cases are checked for impact and updated if required (2).
4. [ ] Unit tests are added unless there is a reason to omit them.
5. [ ] Automated tests are added when required.
6. [ ] The code is merged.
7. [ ] Tech documentation is added / updated, reviewed and approved (including mandatory approval by a code owner, should such exist for changed files).
    - [ ] BE: Swagger documentation is updated.
8. [ ] When required by QA:
    - [ ] Deployed to the relevant environment.
    - [ ] Passed system tests.

---

(1) Developer(s) in coordination with QA decide whether it's required. For small tickets introducing small changes QA assistance is most probably not required.

(2) [Octant Areas & Test Cases](https://docs.google.com/spreadsheets/d/1cRe6dxuKJV3a4ZskAwWEPvrFkQm6rEfyUCYwLTYw_Cc).
