### PR TITLE
OCT-2002: Allocate drawer / view should show allocation buttons even when user has no rewards or no projects added

### DIFF
--- a/client/src/components/Allocation/Allocation.tsx
+++ b/client/src/components/Allocation/Allocation.tsx
@@ -477,13 +477,6 @@ const Allocation = (): ReactElement => {
     (allocationValues !== undefined && !isEmpty(allocations)) ||
     (!!userAllocations?.hasUserAlreadyDoneAllocation && userAllocations.elements.length > 0);
   const hasUserIndividualReward = !!individualReward && individualReward !== 0n;
-  const areButtonsDisabled =
-    isLoading ||
-    !isConnected ||
-    !isDecisionWindowOpen ||
-    (!areAllocationsAvailableOrAlreadyDone && rewardsForProjects !== 0n) ||
-    !individualReward ||
-    isWaitingForFirstMultisigSignature;
 
   const allocationsWithRewards = getAllocationsWithRewards({
     allocationValues,
@@ -494,11 +487,14 @@ const Allocation = (): ReactElement => {
 
   const isEpoch1 = currentEpoch === 1;
 
-  const showAllocationBottomNavigation =
-    !isEpoch1 &&
-    (areAllocationsAvailableOrAlreadyDone || rewardsForProjects === 0n) &&
-    hasUserIndividualReward &&
-    isDecisionWindowOpen;
+  const areButtonsDisabled =
+    isEpoch1 ||
+    isLoading ||
+    !isConnected ||
+    !isDecisionWindowOpen ||
+    (!areAllocationsAvailableOrAlreadyDone && rewardsForProjects !== 0n) ||
+    !hasUserIndividualReward ||
+    isWaitingForFirstMultisigSignature;
 
   useEffect(() => {
     if (!walletAddress || !isContract || isWaitingForFirstMultisigSignature) {
@@ -540,10 +536,7 @@ const Allocation = (): ReactElement => {
       <div className={styles.title}>{t('allocateRewards')}</div>
       <div
         ref={boxesWrapperRef}
-        className={cx(
-          styles.boxesWrapper,
-          isDesktop && showAllocationBottomNavigation && styles.withMarginBottom,
-        )}
+        className={cx(styles.boxesWrapper, isDesktop && styles.withMarginBottom)}
       >
         {!isEpoch1 && (
           <AllocationRewardsBox
@@ -616,8 +609,7 @@ const Allocation = (): ReactElement => {
           onAllocate={() => onAllocate(true)}
         />
 
-        {showAllocationBottomNavigation &&
-          (isDesktop ? boxesWrapperRef.current : navRef.current) &&
+        {(isDesktop ? boxesWrapperRef.current : navRef.current) &&
           createPortal(
             <AllocationNavigation
               areButtonsDisabled={areButtonsDisabled}
@@ -627,10 +619,11 @@ const Allocation = (): ReactElement => {
                 isWaitingForFirstMultisigSignature
               }
               isLoading={
-                allocateEvent.isLoading ||
-                isWaitingForAllMultisigSignatures ||
-                isWaitingForFirstMultisigSignature ||
-                isLoading
+                !areButtonsDisabled &&
+                (allocateEvent.isLoading ||
+                  isWaitingForAllMultisigSignatures ||
+                  isWaitingForFirstMultisigSignature ||
+                  isLoading)
               }
               isWaitingForAllMultisigSignatures={
                 isWaitingForAllMultisigSignatures || isWaitingForFirstMultisigSignature


### PR DESCRIPTION
## Description

## Definition of Done

1. [ ] If required, the desciption of your change is added to the [QA changelog](https://www.notion.so/octantapp/Changelog-for-the-QA-d96fa3b411cf488bb1d8d9a598d88281) 
2. [ ] Acceptance criteria are met.
3. [ ] PR is manually tested before the merge by developer(s).
    - [ ] Happy path is manually checked.
4. [ ] PR is manually tested by QA when their assistance is required (1).
    - [ ] Octant Areas & Test Cases are checked for impact and updated if required (2).
5. [ ] Unit tests are added unless there is a reason to omit them.
6. [ ] Automated tests are added when required.
7. [ ] The code is merged.
8. [ ] Tech documentation is added / updated, reviewed and approved (including mandatory approval by a code owner, should such exist for changed files).
    - [ ] BE: Swagger documentation is updated.
9. [ ] When required by QA:
    - [ ] Deployed to the relevant environment.
    - [ ] Passed system tests.

---

(1) Developer(s) in coordination with QA decide whether it's required. For small tickets introducing small changes QA assistance is most probably not required.

(2) [Octant Areas & Test Cases](https://docs.google.com/spreadsheets/d/1cRe6dxuKJV3a4ZskAwWEPvrFkQm6rEfyUCYwLTYw_Cc).
