### PR TITLE
localenv: don't rely on fancy 'new' features of docker

### DIFF
--- a/ci/Dockerfile.multideployer
+++ b/ci/Dockerfile.multideployer
@@ -9,8 +9,10 @@ WORKDIR /app
 RUN mkdir /hardhat/
 COPY --from=hardhat /app/ /hardhat/
 
-COPY --chmod=+x entrypoint.sh .
-COPY --chmod=+x wait_for_subgraph.sh .
+COPY entrypoint.sh .
+RUN chmod +x ./entrypoint.sh
+COPY wait_for_subgraph.sh .
+RUN chmod +x ./wait_for_subgraph.sh
 COPY server.py /app/server.py
 
 ENTRYPOINT ["./entrypoint.sh"]

--- a/localenv/multideployer/Dockerfile
+++ b/localenv/multideployer/Dockerfile
@@ -11,8 +11,10 @@ RUN npx hardhat compile
 
 WORKDIR /app/
 
-COPY --chmod=+x entrypoint.sh .
-COPY --chmod=+x wait_for_subgraph.sh .
+COPY entrypoint.sh .
+RUN chmod +x ./entrypoint.sh
+COPY wait_for_subgraph.sh .
+RUN chmod +x ./wait_for_subgraph.sh
 COPY server.py /app/server.py
 
 ENTRYPOINT ["./entrypoint.sh"]


### PR DESCRIPTION
A very minor improvement - will allow localenv work with older versions of docker.