### PR TITLE
OCT-2178: Removes verbose logging on 404 while it's actually handled in code

### DIFF
--- a/backend/app/infrastructure/external_api/safe/message_details.py
+++ b/backend/app/infrastructure/external_api/safe/message_details.py
@@ -1,3 +1,4 @@
+from http import HTTPStatus
 import requests
 
 import app as app_module
@@ -13,7 +14,8 @@ def get_message_details(message_hash: str, is_mainnet: bool) -> dict:
         response.raise_for_status()
         json_response = response.json()
     except requests.exceptions.RequestException as e:
-        app_module.ExceptionHandler.print_stacktrace(e)
+        if response.status_code != HTTPStatus.NOT_FOUND:
+            app_module.ExceptionHandler.print_stacktrace(e)
         raise ExternalApiException(e)
 
     return json_response


### PR DESCRIPTION
## Description
We are logging `get_message_details()` 404 errors into stderr while they are actually  handled and expected by then logic. Really simple fix here

## Definition of Done

1. [ ] If required, the desciption of your change is added to the [QA changelog](https://www.notion.so/octantapp/Changelog-for-the-QA-d96fa3b411cf488bb1d8d9a598d88281) 
2. [ ] Acceptance criteria are met.
3. [ ] PR is manually tested before the merge by developer(s).
    - [ ] Happy path is manually checked.
4. [ ] PR is manually tested by QA when their assistance is required (1).
    - [ ] Octant Areas & Test Cases are checked for impact and updated if required (2).
5. [ ] Unit tests are added unless there is a reason to omit them.
6. [ ] Automated tests are added when required.
7. [ ] The code is merged.
8. [ ] Tech documentation is added / updated, reviewed and approved (including mandatory approval by a code owner, should such exist for changed files).
    - [ ] BE: Swagger documentation is updated.
9. [ ] When required by QA:
    - [ ] Deployed to the relevant environment.
    - [ ] Passed system tests.

---

(1) Developer(s) in coordination with QA decide whether it's required. For small tickets introducing small changes QA assistance is most probably not required.

(2) [Octant Areas & Test Cases](https://docs.google.com/spreadsheets/d/1cRe6dxuKJV3a4ZskAwWEPvrFkQm6rEfyUCYwLTYw_Cc).
