### PR TITLE
fix(api): make octant optional in externalAddresses

### DIFF
--- a/client/src/api/calls/karmaGap.ts
+++ b/client/src/api/calls/karmaGap.ts
@@ -3,6 +3,10 @@ import apiService from 'services/apiService';
 
 export type GrantsPerProgram = {
   data: {
+    // externalAddresses is set only when recipient does not match project has in Octant.
+    externalAddresses?: {
+      octant?: string;
+    };
     milestones: {
       createdAt: string;
       data: {
@@ -23,7 +27,7 @@ export type GrantsPerProgram = {
       };
       // externalAddresses is set only when recipient does not match project has in Octant.
       externalAddresses?: {
-        octant: string;
+        octant?: string;
       };
       recipient: string;
     };

--- a/client/src/hooks/queries/karmaGap/useMilestonesPerGrantPerProgram.ts
+++ b/client/src/hooks/queries/karmaGap/useMilestonesPerGrantPerProgram.ts
@@ -17,9 +17,14 @@ export default function useMilestonesPerGrantPerProgram(
     select: response =>
       response.data.find(
         element =>
-          element.project.externalAddresses?.octant.toLowerCase() === projectAddressToLowerCase ||
-          element.project.recipient.toLowerCase() === projectAddressToLowerCase ||
-          element.project.details.recipient.toLowerCase() === projectAddressToLowerCase,
+					element.project?.externalAddresses?.octant?.toLowerCase() ===
+						projectAddressToLowerCase ||
+					element?.externalAddresses?.octant?.toLowerCase() ===
+						projectAddressToLowerCase ||
+					element.project.recipient.toLowerCase() ===
+						projectAddressToLowerCase ||
+					element.project.details.recipient.toLowerCase() ===
+						projectAddressToLowerCase,
       ),
   });
 }


### PR DESCRIPTION
## Description
I was checking that projects like https://octant.app/project/4/0x00080706a7D99CBC163D52dcF435205B1aD940D1 and https://octant.app/project/4/0xe126b3E5d052f1F575828f61fEBA4f4f2603652a and for some reason, it's not showing the milestones there properly. 
The issue is: at `client/src/hooks/queries/karmaGap/useMilestonesPerGrantPerProgram.ts` where it's checking for `element.project?.externalAddresses?.octant?.toLowerCase() === projectAddressToLowerCase` condition, but it's on the API request, it's being received as `element.project?.externalAddresses?.oso` and it's throwing an typescript error.
And we also are adding `element?.externalAddresses?.octant` as fallback option.
