### PR TITLE
[KARMA GAP] API change - externalAddresses to external in GrantPerProgram type

### DIFF
--- a/client/src/api/calls/karmaGap.ts
+++ b/client/src/api/calls/karmaGap.ts
@@ -21,9 +21,9 @@ export type Milestone = {
 };
 
 export type GrantPerProgram = {
-  // externalAddresses is set only when recipient does not match project has in Octant.
-  externalAddresses?: {
-    octant?: string;
+  // external is set only when recipient does not match project has in Octant.
+  external?: {
+    octant?: string[];
   };
   milestones: Milestone[];
   project: {

--- a/client/src/hooks/queries/karmaGap/useMilestonesPerGrantPerProgram.ts
+++ b/client/src/hooks/queries/karmaGap/useMilestonesPerGrantPerProgram.ts
@@ -27,7 +27,9 @@ export default function useMilestonesPerGrantPerProgram(
       }
       return response.data.find(
         element =>
-          element.externalAddresses?.octant?.toLowerCase() === projectAddressToLowerCase ||
+          element.external?.octant
+            ?.map(octant => octant.toLowerCase())
+            .includes(projectAddressToLowerCase) ||
           element.project.recipient.toLowerCase() === projectAddressToLowerCase ||
           element.project.details.recipient.toLowerCase() === projectAddressToLowerCase,
       );


### PR DESCRIPTION
## Description
- Karma GAP recently refactored its API response schema. This PR makes the neceessary changes.
- Changed the property name from `externalAddresses` to `external` in the `GrantPerProgram` type definition.
- Updated the query logic in `useMilestonesPerGrantPerProgram` to accommodate the new property structure, ensuring compatibility with the updated type.

## Definition of Done

1. [ ] If required, the desciption of your change is added to the [QA changelog](https://www.notion.so/octantapp/Changelog-for-the-QA-d96fa3b411cf488bb1d8d9a598d88281) 
2. [X] Acceptance criteria are met.
3. [ ] PR is manually tested before the merge by developer(s).
    - [ ] Happy path is manually checked.
4. [ ] PR is manually tested by QA when their assistance is required (1).
    - [ ] Octant Areas & Test Cases are checked for impact and updated if required (2).
5. [ ] Unit tests are added unless there is a reason to omit them.
6. [ ] Automated tests are added when required.
7. [ ] The code is merged.
8. [ ] Tech documentation is added / updated, reviewed and approved (including mandatory approval by a code owner, should such exist for changed files).
    - [ ] BE: Swagger documentation is updated.
9. [ ] When required by QA:
    - [ ] Deployed to the relevant environment.
    - [ ] Passed system tests.

---

(1) Developer(s) in coordination with QA decide whether it's required. For small tickets introducing small changes QA assistance is most probably not required.

(2) [Octant Areas & Test Cases](https://docs.google.com/spreadsheets/d/1cRe6dxuKJV3a4ZskAwWEPvrFkQm6rEfyUCYwLTYw_Cc).
