### PR TITLE
OCT-2363: Fixing rewards/threshold outside of AW

### DIFF
--- a/backend/v2/allocations/socket.py
+++ b/backend/v2/allocations/socket.py
@@ -71,7 +71,6 @@ async def create_dependencies_on_connect() -> AsyncGenerator[
                 epoch_number,
                 session,
                 projects_contracts,
-                get_projects_allocation_threshold_settings(),
             )
             estimated_matched_rewards = await get_matched_rewards_estimator_only_in_aw(
                 epoch_number,
@@ -128,7 +127,6 @@ async def create_dependencies_on_allocate() -> AsyncGenerator[
                 epoch_number,
                 session,
                 projects_contracts,
-                get_projects_allocation_threshold_settings(),
             )
             estimated_matched_rewards = await get_matched_rewards_estimator_only_in_aw(
                 epoch_number,

--- a/backend/v2/allocations/socket.py
+++ b/backend/v2/allocations/socket.py
@@ -32,8 +32,7 @@ from v2.matched_rewards.dependencies import (
 from v2.project_rewards.dependencies import get_project_rewards_estimator
 from v2.project_rewards.services import ProjectRewardsEstimator
 from v2.projects.dependencies import (
-    get_projects_allocation_threshold_getter,
-    get_projects_allocation_threshold_settings,
+    get_projects_allocation_threshold_getter_in_open_aw,
     get_projects_contracts,
     get_projects_settings,
 )
@@ -68,7 +67,7 @@ async def create_dependencies_on_connect() -> AsyncGenerator[
 
     async with sessionmaker() as session:
         try:
-            threshold_getter = get_projects_allocation_threshold_getter(
+            threshold_getter = get_projects_allocation_threshold_getter_in_open_aw(
                 epoch_number,
                 session,
                 projects_contracts,
@@ -125,7 +124,7 @@ async def create_dependencies_on_allocate() -> AsyncGenerator[
 
     async with sessionmaker() as session:
         try:
-            threshold_getter = get_projects_allocation_threshold_getter(
+            threshold_getter = get_projects_allocation_threshold_getter_in_open_aw(
                 epoch_number,
                 session,
                 projects_contracts,

--- a/backend/v2/project_rewards/router.py
+++ b/backend/v2/project_rewards/router.py
@@ -451,7 +451,6 @@ async def get_rewards_for_projects_in_epoch_v1(
 
 @api.get("/threshold/{epoch_number}")
 async def get_rewards_threshold_v1(
-    epoch_number: int,
     projects_allocation_threshold_getter: GetProjectsAllocationThresholdGetter,
 ) -> ThresholdResponseV1:
     threshold = await projects_allocation_threshold_getter.get()

--- a/backend/v2/project_rewards/schemas.py
+++ b/backend/v2/project_rewards/schemas.py
@@ -84,7 +84,7 @@ class UpcomingUserBudgetResponseV1(OctantModel):
 
 
 class ThresholdResponseV1(OctantModel):
-    threshold: BigInteger = Field(
+    threshold: BigInteger | None = Field(
         ...,
         description="Threshold, that projects have to pass to be eligible for receiving rewards.",
     )

--- a/backend/v2/projects/dependencies.py
+++ b/backend/v2/projects/dependencies.py
@@ -48,13 +48,6 @@ class ProjectsSettings(OctantSettings):
         return compare_blockchain_types(self.chain_id, ChainTypes.MAINNET)
 
 
-class ProjectsAllocationThresholdSettings(OctantSettings):
-    project_count_multiplier: int = Field(
-        default=1,
-        description="The multiplier to the number of projects to calculate the allocation threshold.",
-    )
-
-
 def get_projects_settings() -> ProjectsSettings:
     return ProjectsSettings()  # type: ignore[call-arg]
 
@@ -67,22 +60,20 @@ def get_projects_contracts(
     )  # type: ignore[arg-type]
 
 
-def get_projects_allocation_threshold_settings() -> ProjectsAllocationThresholdSettings:
-    return ProjectsAllocationThresholdSettings()
-
-
-def get_projects_allocation_threshold_getter(
+def get_projects_allocation_threshold_getter_in_open_aw(
     epoch_number: GetOpenAllocationWindowEpochNumber,
     session: GetSession,
     projects: GetProjectsContracts,
-    settings: Annotated[
-        ProjectsAllocationThresholdSettings,
-        Depends(get_projects_allocation_threshold_settings),
-    ],
 ) -> ProjectsAllocationThresholdGetter:
-    return ProjectsAllocationThresholdGetter(
-        epoch_number, session, projects, settings.project_count_multiplier
-    )
+    return ProjectsAllocationThresholdGetter(epoch_number, session, projects)
+
+
+def get_projects_allocation_threshold_getter(
+    epoch_number: EpochNumberPath,
+    session: GetSession,
+    projects: GetProjectsContracts,
+) -> ProjectsAllocationThresholdGetter:
+    return ProjectsAllocationThresholdGetter(epoch_number, session, projects)
 
 
 async def get_projects_metadata_getter(

--- a/backend/v2/projects/services/projects_allocation_threshold_getter.py
+++ b/backend/v2/projects/services/projects_allocation_threshold_getter.py
@@ -14,14 +14,12 @@ class ProjectsAllocationThresholdGetter:
     # Dependencies
     session: AsyncSession
     projects: ProjectsContracts
-    project_count_multiplier: int = 1
 
     async def get(self) -> int:
         return await get_projects_allocation_threshold(
             session=self.session,
             projects=self.projects,
             epoch_number=self.epoch_number,
-            project_count_multiplier=self.project_count_multiplier,
         )
 
 
@@ -31,9 +29,15 @@ async def get_projects_allocation_threshold(
     projects: ProjectsContracts,
     # Arguments
     epoch_number: int,
-    project_count_multiplier: int = 1,
-) -> int:
-    # PROJECTS_COUNT_MULTIPLIER = 1  # TODO: from settings?
+) -> int | None:
+    # We do not use threshold for epoch 4 and above - it's not needed
+    if epoch_number >= 4:
+        return None
+
+    if epoch_number in [1, 2]:
+        project_count_multiplier = 2
+    else:
+        project_count_multiplier = 1
 
     total_allocated = await sum_allocations_by_epoch(session, epoch_number)
     project_addresses = await projects.get_project_addresses(epoch_number)


### PR DESCRIPTION
## Description

Fixing `rewards/threshold/{epoch_number}` outside of AW
Removed check if AW is open, adjusted the project multiplier per epoch as it was misaligned aswell.
