### PR TITLE
[FEAT]: Karma GAP Epoch 8 id

### DIFF
--- a/client/src/constants/karmaGap.ts
+++ b/client/src/constants/karmaGap.ts
@@ -8,6 +8,7 @@ export const PROGRAMS_IDS_TO_EPOCH_NUMBER_MAPPING = {
   5: '548_42161',
   6: '773_42161',
   7: '887_42161',
+  8: '945_42161',
 };
 /* eslint-enable @typescript-eslint/naming-convention */
 


### PR DESCRIPTION
`id` is required for FE to identify epoch 8 in Karma GAP API response.