### PR TITLE
fix(migration): drive migrate modal off live status + guard wallet client

### DIFF
--- a/client/src/api/errorMessages/index.ts
+++ b/client/src/api/errorMessages/index.ts
@@ -2,6 +2,7 @@
 import { Query } from '@tanstack/react-query';
 
 import { QUERY_KEYS, ROOTS } from 'api/queryKeys';
+import { WALLET_NOT_AVAILABLE_REASON } from 'hooks/contracts/writeContracts';
 import i18n from 'i18n';
 import toastService from 'services/toastService';
 
@@ -43,6 +44,11 @@ const errors: QueryMutationErrorConfig = {
   },
   'History/loading-encountered-an-error': {
     message: i18n.t('api.errorMessage.history.loadingEncounteredAnError'),
+    type: 'toast',
+  },
+  [WALLET_NOT_AVAILABLE_REASON]: {
+    message: i18n.t('api.errorMessage.walletNotAvailable.message'),
+    title: i18n.t('api.errorMessage.walletNotAvailable.title'),
     type: 'toast',
   },
 };

--- a/client/src/components/Home/ModalMigration/ModalMigration.tsx
+++ b/client/src/components/Home/ModalMigration/ModalMigration.tsx
@@ -14,7 +14,6 @@ import {
 import env from 'env';
 import useUserMigrationStatus, { UserMigrationStatus } from 'hooks/helpers/useUserMigrationStatus';
 import useMigrateDepositToV2 from 'hooks/mutations/useMigrateDepositToV2';
-import useDepositValue from 'hooks/queries/useDepositValue';
 import useUserSablierStreams from 'hooks/queries/useUserSablierStreams';
 
 import styles from './ModalMigration.module.scss';
@@ -38,13 +37,12 @@ const ModalMigration: FC<ModalMigrationProps> = ({
     refetch: refetchUserMigrationStatus,
   } = useUserMigrationStatus();
 
-  // Live v1 deposit value. The migration status below is frozen on open, so we
-  // rely on this to detect when there is nothing left in v1 to migrate.
-  const { data: depositsValue } = useDepositValue();
-
-  const [initialUserMigrationStatus] = useState<UserMigrationStatus | undefined>(
-    userMigrationStatus,
-  );
+  // Snapshot of the migration status taken when the modal opens (see the effect
+  // below). It keeps the multi-step flow stable while the migration runs and the
+  // live status flips, without freezing a stale value captured during loading.
+  const [initialUserMigrationStatus, setInitialUserMigrationStatus] = useState<
+    UserMigrationStatus | undefined
+  >(undefined);
 
   const shouldV2DepositBeTriggered = initialUserMigrationStatus === 'migration_required';
 
@@ -65,12 +63,20 @@ const ModalMigration: FC<ModalMigrationProps> = ({
   });
 
   useEffect(() => {
-    if (!modalPropsRest.isOpen) {
+    if (modalPropsRest.isOpen) {
+      // The modal can only be opened when the live status says a migration is
+      // actionable, so the data is loaded by now. Snapshotting here (rather than
+      // on mount) avoids freezing the loading-time default and makes the modal
+      // act on the real status.
+      setInitialUserMigrationStatus(userMigrationStatus);
+    } else {
       setCurrentStep(0);
       setIsConsentGiven(false);
       setError('');
       setSuccessMessage('');
+      setInitialUserMigrationStatus(undefined);
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [modalPropsRest.isOpen]);
 
   // eslint-disable-next-line @typescript-eslint/naming-convention
@@ -209,14 +215,6 @@ const ModalMigration: FC<ModalMigrationProps> = ({
                 currentStep === 0
                   ? () => setCurrentStep(1)
                   : () => {
-                      if (depositsValue === 0n) {
-                        // Nothing left in v1 to migrate (e.g. the user already
-                        // migrated in this session). Reflect the done state
-                        // instead of firing the migration.
-                        setError('');
-                        setSuccessMessage(t('migrationNotifications.success'));
-                        return;
-                      }
                       if (
                         (initialUserMigrationStatus === 'migration_required' && isConsentGiven) ||
                         initialUserMigrationStatus === 'lock_too_small_for_v2'

--- a/client/src/components/Home/ModalMigration/ModalMigration.tsx
+++ b/client/src/components/Home/ModalMigration/ModalMigration.tsx
@@ -14,6 +14,7 @@ import {
 import env from 'env';
 import useUserMigrationStatus, { UserMigrationStatus } from 'hooks/helpers/useUserMigrationStatus';
 import useMigrateDepositToV2 from 'hooks/mutations/useMigrateDepositToV2';
+import useDepositValue from 'hooks/queries/useDepositValue';
 import useUserSablierStreams from 'hooks/queries/useUserSablierStreams';
 
 import styles from './ModalMigration.module.scss';
@@ -36,6 +37,10 @@ const ModalMigration: FC<ModalMigrationProps> = ({
     data: { userMigrationStatus },
     refetch: refetchUserMigrationStatus,
   } = useUserMigrationStatus();
+
+  // Live v1 deposit value. The migration status below is frozen on open, so we
+  // rely on this to detect when there is nothing left in v1 to migrate.
+  const { data: depositsValue } = useDepositValue();
 
   const [initialUserMigrationStatus] = useState<UserMigrationStatus | undefined>(
     userMigrationStatus,
@@ -204,6 +209,14 @@ const ModalMigration: FC<ModalMigrationProps> = ({
                 currentStep === 0
                   ? () => setCurrentStep(1)
                   : () => {
+                      if (depositsValue === 0n) {
+                        // Nothing left in v1 to migrate (e.g. the user already
+                        // migrated in this session). Reflect the done state
+                        // instead of firing the migration.
+                        setError('');
+                        setSuccessMessage(t('migrationNotifications.success'));
+                        return;
+                      }
                       if (
                         (initialUserMigrationStatus === 'migration_required' && isConsentGiven) ||
                         initialUserMigrationStatus === 'lock_too_small_for_v2'

--- a/client/src/hooks/contracts/writeContracts.ts
+++ b/client/src/hooks/contracts/writeContracts.ts
@@ -14,6 +14,36 @@ type WriteContract = {
   walletClient: any; // UseWalletClientReturnType<any, any, any>;
 };
 
+/**
+ * Reason carried by {@link walletNotAvailableError}. Mapped to a user-facing
+ * message in `api/errorMessages`.
+ */
+export const WALLET_NOT_AVAILABLE_REASON = 'wallet/not-available';
+
+/**
+ * Error surfaced when the wagmi wallet client is unavailable (wallet
+ * disconnected / locked / on an unsupported network). It carries a `reason` so
+ * the global error handler shows an actionable message instead of the generic
+ * "something went wrong" toast or an opaque "cannot read properties of
+ * undefined" TypeError.
+ */
+export function walletNotAvailableError(): Error {
+  return Object.assign(new Error('Wallet client is not available'), {
+    reason: WALLET_NOT_AVAILABLE_REASON,
+  });
+}
+
+/**
+ * Narrows the wagmi wallet client to a defined value, throwing a mapped error
+ * when it is missing instead of letting `walletClient!.writeContract` blow up.
+ */
+export function assertWalletClient<T>(walletClient: T | undefined | null): NonNullable<T> {
+  if (!walletClient) {
+    throw walletNotAvailableError();
+  }
+  return walletClient as NonNullable<T>;
+}
+
 export function writeContractERC20({
   walletClient,
   functionName,

--- a/client/src/hooks/helpers/useUserMigrationStatus.ts
+++ b/client/src/hooks/helpers/useUserMigrationStatus.ts
@@ -52,8 +52,11 @@ function useUserMigrationStatus(): {
       return 'migration_not_required';
     }
     if (depositsValue === undefined || regenStakerMinimumStakeAmount === undefined) {
-      // Does not matter, isFetching won't show status in UI anyway.
-      return 'migration_required';
+      // Until the on-chain data is loaded we cannot know there is anything to
+      // migrate. Defaulting to 'migration_required' here previously opened the
+      // migration modal and let the user trigger a migration with no v1 deposit,
+      // which failed with a generic "something went wrong" toast.
+      return 'migration_not_required';
     }
     if (!doesUserHaveV1Lock && doesUserHaveV2Deposits) {
       return 'migration_done';
@@ -65,7 +68,13 @@ function useUserMigrationStatus(): {
       return 'lock_too_small_for_v2';
     }
     return 'migration_not_required';
-  }, [isConnected, doesUserHaveV1Lock, doesUserHaveV2Deposits, depositsValue, regenStakerMinimumStakeAmount]);
+  }, [
+    isConnected,
+    doesUserHaveV1Lock,
+    doesUserHaveV2Deposits,
+    depositsValue,
+    regenStakerMinimumStakeAmount,
+  ]);
 
   const translationSuffix = useMemo(() => {
     if (status === 'migration_required') {

--- a/client/src/hooks/mutations/useLock.ts
+++ b/client/src/hooks/mutations/useLock.ts
@@ -2,7 +2,7 @@ import { useMutation, UseMutationOptions, UseMutationResult } from '@tanstack/re
 import { Hash } from 'viem';
 import { useWalletClient } from 'wagmi';
 
-import { writeContractDeposits } from 'hooks/contracts/writeContracts';
+import { assertWalletClient, writeContractDeposits } from 'hooks/contracts/writeContracts';
 
 export default function useLock(
   options?: UseMutationOptions<{ hash: Hash; value: bigint }, unknown, bigint>,
@@ -14,7 +14,7 @@ export default function useLock(
       writeContractDeposits({
         args: [`0x${value.toString(16)}`],
         functionName: 'lock',
-        walletClient: walletClient!,
+        walletClient: assertWalletClient(walletClient),
       }).then(data => ({
         hash: data,
         value,

--- a/client/src/hooks/mutations/useMigrateDepositToV2.ts
+++ b/client/src/hooks/mutations/useMigrateDepositToV2.ts
@@ -55,8 +55,19 @@ export default function useMigrateDepositToV2({
 
   return useMutation<TransactionReceipt | null, Error, void, unknown>({
     mutationFn: async () => {
-      if (!depositsValue) {
+      if (depositsValue === undefined) {
         throw new Error('depositsValue is undefined');
+      }
+
+      if (depositsValue === 0n) {
+        /**
+         * No v1 deposit left to migrate (e.g. the user already migrated).
+         * Return early instead of attempting a pointless unlock(0).
+         * Previously the `!depositsValue` check treated 0n as falsy and threw
+         * a plain Error here, which the global mutation error handler surfaced
+         * as the generic "Sorry, something went wrong there" toast.
+         */
+        return null;
       }
 
       // Ensure we reset state and properly propagate any error so react-query exposes it

--- a/client/src/hooks/mutations/useUnlock.ts
+++ b/client/src/hooks/mutations/useUnlock.ts
@@ -2,7 +2,7 @@ import { UseMutationResult, useMutation, UseMutationOptions } from '@tanstack/re
 import { Hash } from 'viem';
 import { useWalletClient } from 'wagmi';
 
-import { writeContractDeposits } from 'hooks/contracts/writeContracts';
+import { assertWalletClient, writeContractDeposits } from 'hooks/contracts/writeContracts';
 
 export default function useUnlock(
   options?: UseMutationOptions<{ hash: Hash; value: bigint }, unknown, bigint>,
@@ -14,7 +14,7 @@ export default function useUnlock(
       writeContractDeposits({
         args: [`0x${value.toString(16)}`],
         functionName: 'unlock',
-        walletClient: walletClient!,
+        walletClient: assertWalletClient(walletClient),
       }).then(data => ({
         hash: data,
         value,

--- a/client/src/hooks/mutations/useV2StakeMoreMutation.ts
+++ b/client/src/hooks/mutations/useV2StakeMoreMutation.ts
@@ -3,7 +3,7 @@ import { erc20Abi, Hash, TransactionReceipt } from 'viem';
 import { usePublicClient, useWalletClient } from 'wagmi';
 
 import env from 'env';
-import { writeContractRegenStaker } from 'hooks/contracts/writeContracts';
+import { walletNotAvailableError, writeContractRegenStaker } from 'hooks/contracts/writeContracts';
 
 type UseStakeMoreMutationParams = {
   depositAmount: bigint;
@@ -24,7 +24,7 @@ export default function useStakeMoreMutation() {
       // eslint-disable-next-line no-async-promise-executor
       new Promise<TransactionReceipt>(async (resolve, reject) => {
         if (!walletClient) {
-          reject(new Error('walletClient is undefined'));
+          reject(walletNotAvailableError());
           return;
         }
 

--- a/client/src/hooks/mutations/useV2StakeMutation.ts
+++ b/client/src/hooks/mutations/useV2StakeMutation.ts
@@ -3,7 +3,7 @@ import { erc20Abi, Hash, TransactionReceipt } from 'viem';
 import { usePublicClient, useWalletClient } from 'wagmi';
 
 import env from 'env';
-import { writeContractRegenStaker } from 'hooks/contracts/writeContracts';
+import { walletNotAvailableError, writeContractRegenStaker } from 'hooks/contracts/writeContracts';
 
 type UseStakeMutationParams = {
   depositAmount: bigint;
@@ -23,7 +23,7 @@ export default function useStakeMutation() {
       // eslint-disable-next-line no-async-promise-executor
       new Promise<TransactionReceipt>(async (resolve, reject) => {
         if (!walletClient) {
-          reject(new Error('walletClient is undefined'));
+          reject(walletNotAvailableError());
           return;
         }
 

--- a/client/src/hooks/mutations/useWithdrawEth.ts
+++ b/client/src/hooks/mutations/useWithdrawEth.ts
@@ -2,7 +2,7 @@ import { UseMutationResult, useMutation, UseMutationOptions } from '@tanstack/re
 import { Hash } from 'viem';
 import { useWalletClient } from 'wagmi';
 
-import { writeContractVault } from 'hooks/contracts/writeContracts';
+import { assertWalletClient, writeContractVault } from 'hooks/contracts/writeContracts';
 
 export interface BatchWithdrawRequest {
   amount: BigInt;
@@ -28,7 +28,7 @@ export default function useWithdrawEth(
       writeContractVault({
         args: [value],
         functionName: 'batchWithdraw',
-        walletClient: walletClient!,
+        walletClient: assertWalletClient(walletClient),
       }).then(data => ({
         hash: data,
         value,

--- a/client/src/locales/en/translation.json
+++ b/client/src/locales/en/translation.json
@@ -14,6 +14,10 @@
         "loadingEncounteredAnError": "Loading of history of operations encountered a problem. Please try again."
       },
       "userRejectedWalletOperation": "Wallet rejected the operation",
+      "walletNotAvailable": {
+        "title": "Wallet not available",
+        "message": "Reconnect your wallet, switch it to Ethereum mainnet, and try again."
+      },
       "default": {
         "title": "Sorry, something went wrong there",
         "message": "Please reload the app and try again"

--- a/client/src/locales/es/translation.json
+++ b/client/src/locales/es/translation.json
@@ -14,6 +14,10 @@
         "loadingEncounteredAnError": "Se ha producido un problema al cargar el historial de operaciones. Por favor, inténtalo nuevamente más tarde."
       },
       "userRejectedWalletOperation": "Cartera rechazó la operación",
+      "walletNotAvailable": {
+        "title": "Cartera no disponible",
+        "message": "Vuelve a conectar tu cartera, cámbiala a la red principal de Ethereum y vuelve a intentarlo."
+      },
       "default": {
         "title": "Lo siento, algo ha fallado.",
         "message": "Por favor, actualiza nuevamente la aplicación y vuelve a intentarlo."


### PR DESCRIPTION
## Reported problem

A user (`0x3e6c23CdAa52B1B6621dBb30c367d16ace21F760`) reported two things in one go:

1. Can't migrate — sees **"Sorry, something went wrong"**.
2. Clicking **"Withdraw rewards"** doesn't load the wallet.

Both are the *same class* of failure: a wallet/data-layer operation throws an **opaque** error that the global handler renders as the generic default toast (or, for withdraw, silently does nothing). On-chain this account has `0` in v1 Deposits and an existing v2 stake, and it's an EIP-7702 smart account — so the migrate modal should never have engaged for it, and neither flow should fail silently.

## Root causes

1. **Migration status wasn't authoritative.** `useUserMigrationStatus` returned `'migration_required'` as its *loading/unknown* default (while `deposits` / min-stake reads were unresolved). `ModalMigration` then froze that status into `initialUserMigrationStatus` via `useState` **at mount** — i.e. during initial load — so the modal believed a migration was required even when it wasn't, opened, and the click threw `depositsValue is undefined` → generic toast.
2. **Falsy bigint guard** in `useMigrateDepositToV2`: `if (!depositsValue)` treated `0n` like `undefined` and threw a plain `Error` (no `reason`).
3. **Unguarded `walletClient!`**: `useUnlock` (migrate step 1), `useWithdrawEth`, and `useLock` did `writeContractX({ walletClient: walletClient! })`. When the wallet client is unavailable this throws an opaque `TypeError` *before* the wallet prompt — migrate → generic toast, withdraw → "nothing happens / wallet doesn't load". Only the v2 stake hooks guarded it.

## Changes

1. `useUserMigrationStatus`: while on-chain data is unknown, return `'migration_not_required'` instead of `'migration_required'` (every consumer already renders the neutral state for it). The migrate tile/modal no longer engages until we actually know there's something to migrate.
2. `ModalMigration`: snapshot the status **when the modal opens** (data loaded by then) instead of freezing the loading-time default at mount; reset on close. Keeps the multi-step flow stable without acting on stale state.
3. `useMigrateDepositToV2`: distinguish `undefined` (throw) from `0n` (no-op `return null`) — defensive, no more falsy-bigint toast or pointless `unlock(0)`.
4. `useUnlock` / `useLock` / `useWithdrawEth`: guard the wallet client via a shared `assertWalletClient`, surfacing an actionable **"Wallet not available — reconnect / switch to Ethereum mainnet"** toast (en + es) instead of an opaque TypeError. The v2 stake hooks are aligned to the same mapped error (`walletNotAvailableError`).

## Honest scope note

Changes 3–4 make the failure modes **correct and actionable** and stop the migrate modal from engaging when there's nothing to migrate. They do **not** by themselves explain *why* this specific EIP-7702 account's wallet/RPC layer was unavailable — pinning that down needs the user's session console/network logs (Octant's Sentry/LogRocket weren't reachable from my environment). Once the wallet client is available, the normal flows run unchanged.

## Testing

1. `yarn type-check` — passes.
2. `eslint` on all changed files — clean.
3. en/es `translation.json` validated as JSON.